### PR TITLE
[rebasing] Keep all installed files in reports

### DIFF
--- a/pkg/fanal/analyzer/pkg/apk/apk.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -47,13 +47,13 @@ func (a alpinePkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInp
 	}, nil
 }
 
-func (a alpinePkgAnalyzer) parseApkInfo(scanner *bufio.Scanner) ([]types.Package, []string) {
+func (a alpinePkgAnalyzer) parseApkInfo(scanner *bufio.Scanner) ([]types.Package, map[string][]string) {
 	var (
 		pkgs           []types.Package
 		pkg            types.Package
 		version        string
 		dir            string
-		installedFiles []string
+		installedFiles = make(map[string][]string)
 		provides       = map[string]string{} // for dependency graph
 	)
 
@@ -89,7 +89,7 @@ func (a alpinePkgAnalyzer) parseApkInfo(scanner *bufio.Scanner) ([]types.Package
 		case "F:":
 			dir = line[2:]
 		case "R:":
-			installedFiles = append(installedFiles, path.Join(dir, line[2:]))
+			pkg.SystemInstalledFiles = append(pkg.SystemInstalledFiles, filepath.Join(dir, line[2:]))
 		case "p:": // provides (corresponds to provides in PKGINFO, concatenated by spaces into a single line)
 			a.parseProvides(line, pkg.ID, provides)
 		case "D:": // dependencies (corresponds to depend in PKGINFO, concatenated by spaces into a single line)
@@ -114,6 +114,9 @@ func (a alpinePkgAnalyzer) parseApkInfo(scanner *bufio.Scanner) ([]types.Package
 	// in case of last paragraph
 	if !pkg.Empty() {
 		pkgs = append(pkgs, pkg)
+	}
+	if pkg.Name != "" {
+		installedFiles[pkg.Name] = pkg.SystemInstalledFiles
 	}
 
 	pkgs = a.uniquePkgs(pkgs)

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
@@ -2,11 +2,12 @@ package dpkg
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/mapfs"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -1319,22 +1320,24 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 			name:      "info list",
 			testFiles: map[string]string{"./testdata/tar.list": "var/lib/dpkg/info/tar.list"},
 			want: &analyzer.AnalysisResult{
-				SystemInstalledFiles: []string{
-					"/bin/tar",
-					"/etc",
-					"/usr/lib/mime/packages/tar",
-					"/usr/sbin/rmt-tar",
-					"/usr/sbin/tarcat",
-					"/usr/share/doc/tar/AUTHORS",
-					"/usr/share/doc/tar/NEWS.gz",
-					"/usr/share/doc/tar/README.Debian",
-					"/usr/share/doc/tar/THANKS.gz",
-					"/usr/share/doc/tar/changelog.Debian.gz",
-					"/usr/share/doc/tar/copyright",
-					"/usr/share/man/man1/tar.1.gz",
-					"/usr/share/man/man1/tarcat.1.gz",
-					"/usr/share/man/man8/rmt-tar.8.gz",
-					"/etc/rmt",
+				SystemInstalledFiles: map[string][]string{
+					"tar": {
+						"/bin/tar",
+						"/etc",
+						"/usr/lib/mime/packages/tar",
+						"/usr/sbin/rmt-tar",
+						"/usr/sbin/tarcat",
+						"/usr/share/doc/tar/AUTHORS",
+						"/usr/share/doc/tar/NEWS.gz",
+						"/usr/share/doc/tar/README.Debian",
+						"/usr/share/doc/tar/THANKS.gz",
+						"/usr/share/doc/tar/changelog.Debian.gz",
+						"/usr/share/doc/tar/copyright",
+						"/usr/share/man/man1/tar.1.gz",
+						"/usr/share/man/man1/tarcat.1.gz",
+						"/usr/share/man/man8/rmt-tar.8.gz",
+						"/etc/rmt",
+					},
 				},
 			},
 		},

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -80,7 +80,7 @@ func (a rpmPkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 	}, nil
 }
 
-func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) (types.Packages, []string, error) {
+func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) (types.Packages, map[string][]string, error) {
 	filePath, err := writeToTempFile(rc)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("temp file error: %w", err)
@@ -103,7 +103,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) (types.Packages, []string, er
 	}
 
 	var pkgs []types.Package
-	var installedFiles []string
+	installedFiles := make(map[string][]string, len(pkgList))
 	provides := map[string]string{}
 	for _, pkg := range pkgList {
 		arch := pkg.Arch
@@ -139,24 +139,26 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) (types.Packages, []string, er
 		}
 
 		p := types.Package{
-			ID:              fmt.Sprintf("%s@%s-%s.%s", pkg.Name, pkg.Version, pkg.Release, pkg.Arch),
-			Name:            pkg.Name,
-			Epoch:           pkg.EpochNum(),
-			Version:         pkg.Version,
-			Release:         pkg.Release,
-			Arch:            arch,
-			SrcName:         srcName,
-			SrcEpoch:        pkg.EpochNum(), // NOTE: use epoch of binary package as epoch of src package
-			SrcVersion:      srcVer,
-			SrcRelease:      srcRel,
-			Modularitylabel: pkg.Modularitylabel,
-			Licenses:        []string{pkg.License},
-			DependsOn:       pkg.Requires, // Will be replaced with package IDs
-			Maintainer:      pkg.Vendor,
-			Digest:          d,
+			ID:                   fmt.Sprintf("%s@%s-%s.%s", pkg.Name, pkg.Version, pkg.Release, pkg.Arch),
+			Name:                 pkg.Name,
+			Epoch:                pkg.EpochNum(),
+			Version:              pkg.Version,
+			Release:              pkg.Release,
+			Arch:                 arch,
+			SrcName:              srcName,
+			SrcEpoch:             pkg.EpochNum(), // NOTE: use epoch of binary package as epoch of src package
+			SrcVersion:           srcVer,
+			SrcRelease:           srcRel,
+			Modularitylabel:      pkg.Modularitylabel,
+			Licenses:             []string{pkg.License},
+			DependsOn:            pkg.Requires, // Will be replaced with package IDs
+			Maintainer:           pkg.Vendor,
+			Digest:               d,
+			SystemInstalledFiles: files,
 		}
+
 		pkgs = append(pkgs, p)
-		installedFiles = append(installedFiles, files...)
+		installedFiles[p.Name] = files
 
 		// It contains mappings between package-providing files and package IDs
 		// e.g.

--- a/pkg/fanal/handler/all/import.go
+++ b/pkg/fanal/handler/all/import.go
@@ -1,6 +1,7 @@
 package all
 
 import (
+	_ "github.com/aquasecurity/trivy/pkg/fanal/handler/dpkg"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/handler/sysfile"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/handler/unpackaged"
 )

--- a/pkg/fanal/handler/dpkg/dpkg.go
+++ b/pkg/fanal/handler/dpkg/dpkg.go
@@ -1,0 +1,59 @@
+package dpkg
+
+import (
+	"context"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
+	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/handler"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func init() {
+	handler.RegisterPostHandlerInit(types.DpkgPostHandler, newDpkgHandler)
+}
+
+const version = 1
+
+type dpkgHook struct{}
+
+func newDpkgHandler(artifact.Option) (handler.PostHandler, error) {
+	return dpkgHook{}, nil
+}
+
+// Handle merges go.mod and go.sum.
+func (h dpkgHook) Handle(_ context.Context, r *analyzer.AnalysisResult, blob *types.BlobInfo) error {
+	if r.OS.Family != os.Debian && r.OS.Family != os.Ubuntu {
+		return nil
+	}
+
+	for i, pkgInfo := range r.PackageInfos {
+		for j, pkg := range pkgInfo.Packages {
+			if len(pkg.SystemInstalledFiles) == 0 {
+				installedFiles, found := r.SystemInstalledFiles[pkg.Name+":"+pkg.Arch]
+				if !found {
+					installedFiles, found = r.SystemInstalledFiles[pkg.Name]
+				}
+				if found {
+					r.PackageInfos[i].Packages[j].SystemInstalledFiles = installedFiles
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (h dpkgHook) Version() int {
+	return version
+}
+
+func (h dpkgHook) Type() types.HandlerType {
+	return types.DpkgPostHandler
+}
+
+func (h dpkgHook) Priority() int {
+	return types.DpkgPostHandlerPriority
+}

--- a/pkg/fanal/handler/dpkg/dpkg_test.go
+++ b/pkg/fanal/handler/dpkg/dpkg_test.go
@@ -1,0 +1,126 @@
+package dpkg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
+	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func Test_dpkgFileFilterHook_Hook(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *analyzer.AnalysisResult
+		want   *analyzer.AnalysisResult
+	}{
+		{
+			name: "happy path",
+			result: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: os.Debian,
+				},
+				SystemInstalledFiles: map[string][]string{
+					"python2.7": {
+						"/",
+						"/usr/bin/pydoc",
+						"/usr/bin/python",
+						"/usr/bin/python2",
+						"/usr/bin/python2.7",
+						"/usr/libexec/platform-python",
+						"/usr/share/doc/python-2.7.5",
+						"/usr/share/doc/python-2.7.5/LICENSE",
+						"/usr/share/doc/python-2.7.5/README",
+						"/usr/share/man/man1/python.1.gz",
+						"/usr/share/man/man1/python2.1.gz",
+						"/usr/share/man/man1/python2.7.1.gz",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.py",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
+						"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
+						"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
+					},
+				},
+				PackageInfos: []types.PackageInfo{
+					{
+						Packages: types.Packages{
+							types.Package{
+								Name: "python2.7",
+							},
+						},
+					},
+				},
+			},
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: os.Debian,
+				},
+				SystemInstalledFiles: map[string][]string{
+					"python2.7": {
+						"/",
+						"/usr/bin/pydoc",
+						"/usr/bin/python",
+						"/usr/bin/python2",
+						"/usr/bin/python2.7",
+						"/usr/libexec/platform-python",
+						"/usr/share/doc/python-2.7.5",
+						"/usr/share/doc/python-2.7.5/LICENSE",
+						"/usr/share/doc/python-2.7.5/README",
+						"/usr/share/man/man1/python.1.gz",
+						"/usr/share/man/man1/python2.1.gz",
+						"/usr/share/man/man1/python2.7.1.gz",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.py",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
+						"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
+						"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
+					},
+				},
+				PackageInfos: []types.PackageInfo{
+					{
+						Packages: types.Packages{
+							types.Package{
+								Name: "python2.7",
+								SystemInstalledFiles: []string{
+									"/",
+									"/usr/bin/pydoc",
+									"/usr/bin/python",
+									"/usr/bin/python2",
+									"/usr/bin/python2.7",
+									"/usr/libexec/platform-python",
+									"/usr/share/doc/python-2.7.5",
+									"/usr/share/doc/python-2.7.5/LICENSE",
+									"/usr/share/doc/python-2.7.5/README",
+									"/usr/share/man/man1/python.1.gz",
+									"/usr/share/man/man1/python2.1.gz",
+									"/usr/share/man/man1/python2.7.1.gz",
+									"/usr/lib64/python2.7/distutils/command/install_egg_info.py",
+									"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
+									"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
+									"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
+									"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
+
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, err := newDpkgHandler(artifact.Option{KeepSystemInstalledFiles: true})
+			require.NoError(t, err)
+			err = h.Handle(context.TODO(), tt.result, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.result, tt.want)
+		})
+	}
+}

--- a/pkg/fanal/handler/sysfile/filter.go
+++ b/pkg/fanal/handler/sysfile/filter.go
@@ -56,15 +56,23 @@ func newSystemFileFilteringPostHandler(artifact.Option) (handler.PostHandler, er
 // Handle removes files installed by OS package manager such as yum.
 func (h systemFileFilteringPostHandler) Handle(_ context.Context, result *analyzer.AnalysisResult, blob *types.BlobInfo) error {
 	var systemFiles []string
-	for _, file := range append(result.SystemInstalledFiles, defaultSystemFiles...) {
-		// Trim leading slashes to be the same format as the path in container images.
-		systemFile := strings.TrimPrefix(file, "/")
-		// We should check the root filepath ("/") and ignore it.
-		// Otherwise libraries with an empty filePath will be removed.
-		if systemFile != "" {
-			systemFiles = append(systemFiles, systemFile)
+
+	appendSystemFiles := func(files []string) {
+		for _, file := range files {
+			// Trim leading slashes to be the same format as the path in container images.
+			systemFile := strings.TrimPrefix(file, "/")
+			// We should check the root filepath ("/") and ignore it.
+			// Otherwise libraries with an empty filePath will be removed.
+			if systemFile != "" {
+				systemFiles = append(systemFiles, systemFile)
+			}
 		}
 	}
+
+	for _, files := range result.SystemInstalledFiles {
+		appendSystemFiles(files)
+	}
+	appendSystemFiles(defaultSystemFiles)
 
 	var apps []types.Application
 	for _, app := range blob.Applications {

--- a/pkg/fanal/handler/sysfile/filter_test.go
+++ b/pkg/fanal/handler/sysfile/filter_test.go
@@ -22,24 +22,26 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 		{
 			name: "happy path",
 			result: &analyzer.AnalysisResult{
-				SystemInstalledFiles: []string{
-					"/",
-					"/usr/bin/pydoc",
-					"/usr/bin/python",
-					"/usr/bin/python2",
-					"/usr/bin/python2.7",
-					"/usr/libexec/platform-python",
-					"/usr/share/doc/python-2.7.5",
-					"/usr/share/doc/python-2.7.5/LICENSE",
-					"/usr/share/doc/python-2.7.5/README",
-					"/usr/share/man/man1/python.1.gz",
-					"/usr/share/man/man1/python2.1.gz",
-					"/usr/share/man/man1/python2.7.1.gz",
-					"/usr/lib64/python2.7/distutils/command/install_egg_info.py",
-					"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
-					"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
-					"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
-					"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
+				SystemInstalledFiles: map[string][]string{
+					"python2.7": {
+						"/",
+						"/usr/bin/pydoc",
+						"/usr/bin/python",
+						"/usr/bin/python2",
+						"/usr/bin/python2.7",
+						"/usr/libexec/platform-python",
+						"/usr/share/doc/python-2.7.5",
+						"/usr/share/doc/python-2.7.5/LICENSE",
+						"/usr/share/doc/python-2.7.5/README",
+						"/usr/share/man/man1/python.1.gz",
+						"/usr/share/man/man1/python2.1.gz",
+						"/usr/share/man/man1/python2.7.1.gz",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.py",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
+						"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
+						"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
+						"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
+					},
 				},
 			},
 			blob: &types.BlobInfo{
@@ -201,8 +203,8 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 		{
 			name: "go binaries",
 			result: &analyzer.AnalysisResult{
-				SystemInstalledFiles: []string{
-					"usr/local/bin/goreleaser",
+				SystemInstalledFiles: map[string][]string{
+					"github.com/goreleaser/goreleaser": {"usr/local/bin/goreleaser"},
 				},
 			},
 			blob: &types.BlobInfo{
@@ -224,8 +226,8 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 		{
 			name: "Rust will not be skipped",
 			result: &analyzer.AnalysisResult{
-				SystemInstalledFiles: []string{
-					"app/Cargo.lock",
+				SystemInstalledFiles: map[string][]string{
+					"Cargo": {"app/Cargo.lock"},
 				},
 			},
 			blob: &types.BlobInfo{

--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -94,6 +94,9 @@ type Package struct {
 	// This is required when using SPDX formats. Otherwise, it will be empty.
 	Digest digest.Digest `json:",omitempty"`
 
+	// Files provided by the package
+	SystemInstalledFiles []string `json:",omitempty"`
+
 	// lines from the lock file where the dependency is written
 	Locations []Location `json:",omitempty"`
 }

--- a/pkg/fanal/types/handler.go
+++ b/pkg/fanal/types/handler.go
@@ -4,11 +4,12 @@ type HandlerType string
 
 const (
 	SystemFileFilteringPostHandler HandlerType = "system-file-filter"
+	DpkgPostHandler                HandlerType = "dpkg"
 	UnpackagedPostHandler          HandlerType = "unpackaged"
 
 	// SystemFileFilteringPostHandlerPriority should be higher than other handlers.
 	// Otherwise, other handlers need to process unnecessary files.
 	SystemFileFilteringPostHandlerPriority = 100
-
-	UnpackagedPostHandlerPriority = 50
+	DpkgPostHandlerPriority                = 50
+	UnpackagedPostHandlerPriority          = 50
 )


### PR DESCRIPTION
## Description
This PR targets ali/new-main-dd which is currently the main branch of trivy.

Cherry pick of https://github.com/aquasecurity/trivy/commit/f428d99221e41cf09d858073ab3a97c9ee001554 with unit test for dpkg_test.go and fix of merge conflicts.

## Motivation

We want to rebase our fork on top of Trivy's main branch. We'll open a PR commit by commit.

https://github.com/aquasecurity/trivy/commit/e0698b692346c24608e3d119199ba81539f2ddfd and https://github.com/aquasecurity/trivy/commit/cf89f4c0d82767c9e7a14dfc8112381b3a33bf55 were already fixed upstream

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
