### PR TITLE
feat: use lazy zap loggers

### DIFF
--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/utils/clock"
 
 	version "github.com/knqyf263/go-deb-version"
-	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
@@ -28,7 +27,6 @@ var (
 
 type options struct {
 	clock clock.Clock
-	l     *zap.SugaredLogger
 }
 
 type option func(*options)
@@ -48,7 +46,6 @@ type Scanner struct {
 // NewScanner is the factory method to return Amazon scanner
 func NewScanner(opts ...option) *Scanner {
 	o := &options{
-		l:     log.Logger,
 		clock: clock.RealClock{},
 	}
 

--- a/pkg/fanal/log/lazy.go
+++ b/pkg/fanal/log/lazy.go
@@ -1,0 +1,99 @@
+package log
+
+import "go.uber.org/zap"
+
+type lazyLogger struct {
+	zapFactory func() (*zap.SugaredLogger, error)
+	zapLogger  *zap.SugaredLogger
+}
+
+// NewLazyLogger creates a new lazy logger with the specified function to call to create zap logger
+func NewLazyLogger(zapFactory func() (*zap.SugaredLogger, error)) lazyLogger {
+	return lazyLogger{zapFactory: zapFactory}
+}
+
+// ZapLogger creates a new zap logger if no logger was created yet
+func (l *lazyLogger) ZapLogger() *zap.SugaredLogger {
+	if l.zapLogger == nil {
+		l.zapLogger, _ = l.zapFactory() // no:lint: errcheck
+	}
+	return l.zapLogger
+}
+
+// Debug uses fmt.Sprint to construct and log a message.
+func (l *lazyLogger) Debug(args ...interface{}) {
+	l.ZapLogger().Debug(args...)
+}
+
+// Debugf uses fmt.Sprintf to log a templated message.
+func (l *lazyLogger) Debugf(template string, args ...interface{}) {
+	l.ZapLogger().Debugf(template, args...)
+}
+
+// Debugw logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+//
+// When debug-level logging is disabled, this is much faster than
+//
+//	s.With(keysAndValues).Debug(msg)
+func (l *lazyLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	l.ZapLogger().Debugw(msg, keysAndValues...)
+}
+
+// Info uses fmt.Sprint to log a templated message.
+func (l *lazyLogger) Info(args ...interface{}) {
+	l.ZapLogger().Info(args...)
+}
+
+// Infof uses fmt.Sprintf to log a templated message.
+func (l *lazyLogger) Infof(template string, args ...interface{}) {
+	l.ZapLogger().Infof(template, args...)
+}
+
+// Infow logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+func (l *lazyLogger) Infow(msg string, keysAndValues ...interface{}) {
+	l.ZapLogger().Infow(msg, keysAndValues...)
+}
+
+// Warn uses fmt.Sprint to log a templated message.
+func (l *lazyLogger) Warn(args ...interface{}) {
+	l.ZapLogger().Warn(args...)
+}
+
+// Warnf uses fmt.Sprintf to log a templated message.
+func (l *lazyLogger) Warnf(template string, args ...interface{}) {
+	l.ZapLogger().Warnf(template, args...)
+}
+
+// Warnw logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+func (l *lazyLogger) Warnw(msg string, keysAndValues ...interface{}) {
+	l.ZapLogger().Warnw(msg, keysAndValues...)
+}
+
+// Error uses fmt.Sprint to log a templated message.
+func (l *lazyLogger) Error(args ...interface{}) {
+	l.ZapLogger().Error(args...)
+}
+
+// Errorf uses fmt.Sprintf to log a templated message.
+func (l *lazyLogger) Errorf(template string, args ...interface{}) {
+	l.ZapLogger().Errorf(template, args...)
+}
+
+// Errorw logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+func (l *lazyLogger) Errorw(msg string, keysAndValues ...interface{}) {
+	l.ZapLogger().Errorw(msg, keysAndValues...)
+}
+
+// Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
+func (l *lazyLogger) Fatal(args ...interface{}) {
+	l.ZapLogger().Fatal(args...)
+}
+
+// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
+func (l *lazyLogger) Fatalf(template string, args ...interface{}) {
+	l.ZapLogger().Fatalf(template, args...)
+}

--- a/pkg/fanal/log/log.go
+++ b/pkg/fanal/log/log.go
@@ -4,14 +4,14 @@ import (
 	"go.uber.org/zap"
 )
 
-var Logger *zap.SugaredLogger
-
-func init() {
-	if logger, err := zap.NewProduction(); err == nil {
-		Logger = logger.Sugar()
+var Logger = NewLazyLogger(func() (*zap.SugaredLogger, error) {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, err
 	}
-}
+	return logger.Sugar(), nil
+})
 
 func SetLogger(l *zap.SugaredLogger) {
-	Logger = l
+	Logger = NewLazyLogger(func() (*zap.SugaredLogger, error) { return l, nil })
 }

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -17,7 +17,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 		return err
 	}
 
-	artifacts, err := trivyk8s.New(cluster, log.Logger).ListArtifacts(ctx)
+	artifacts, err := trivyk8s.New(cluster, log.Logger.ZapLogger()).ListArtifacts(ctx)
 	if err != nil {
 		return xerrors.Errorf("get k8s artifacts error: %w", err)
 	}

--- a/pkg/k8s/commands/namespace.go
+++ b/pkg/k8s/commands/namespace.go
@@ -17,7 +17,7 @@ func namespaceRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) e
 		return err
 	}
 
-	trivyk8s := trivyk8s.New(cluster, log.Logger).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
+	trivyk8s := trivyk8s.New(cluster, log.Logger.ZapLogger()).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
 
 	artifacts, err := trivyk8s.ListArtifacts(ctx)
 	if err != nil {

--- a/pkg/k8s/commands/resource.go
+++ b/pkg/k8s/commands/resource.go
@@ -21,7 +21,7 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 		return err
 	}
 
-	trivyk8s := trivyk8s.New(cluster, log.Logger).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
+	trivyk8s := trivyk8s.New(cluster, log.Logger.ZapLogger()).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
 	runner := newRunner(opts, cluster.GetCurrentContext())
 
 	if len(name) == 0 { // pods or configmaps etc

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -7,7 +7,6 @@ import (
 	xlog "github.com/masahiro331/go-xfs-filesystem/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"golang.org/x/xerrors"
 
 	dlog "github.com/aquasecurity/go-dep-parser/pkg/log"
 	flog "github.com/aquasecurity/trivy/pkg/fanal/log"
@@ -15,38 +14,35 @@ import (
 
 var (
 	// Logger is the global variable for logging
-	Logger      *zap.SugaredLogger
+	Logger = flog.NewLazyLogger(func() (*zap.SugaredLogger, error) {
+		return newZapLogger(false, false)
+	})
 	debugOption bool
 )
-
-func init() {
-	// Set the default logger
-	Logger, _ = NewLogger(false, false) // nolint: errcheck
-}
 
 // InitLogger initialize the logger variable
 func InitLogger(debug, disable bool) (err error) {
 	debugOption = debug
-	Logger, err = NewLogger(debug, disable)
-	if err != nil {
-		return xerrors.Errorf("failed to initialize a logger: %w", err)
-	}
+
+	logger := flog.NewLazyLogger(func() (*zap.SugaredLogger, error) {
+		return newZapLogger(debug, disable)
+	})
 
 	// Set logger for go-dep-parser
-	dlog.SetLogger(Logger)
+	dlog.SetLogger(logger.ZapLogger())
 
 	// Set logger for fanal
-	flog.SetLogger(Logger)
+	flog.SetLogger(logger.ZapLogger())
 
 	// Set logger for go-xfs-filesystem
-	xlog.SetLogger(Logger)
+	xlog.SetLogger(logger.ZapLogger())
 
 	return nil
 
 }
 
-// NewLogger is the factory method to return the instance of logger
-func NewLogger(debug, disable bool) (*zap.SugaredLogger, error) {
+// newZapLogger is the factory method to return the instance of logger
+func newZapLogger(debug, disable bool) (*zap.SugaredLogger, error) {
 	// First, define our level-handling logic.
 	errorPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 		return lvl >= zapcore.ErrorLevel


### PR DESCRIPTION
## Description

Create zap logger on demand. Zap loggers use a significant amount of memory and
are global. Use on demand logger to spare some memory.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
