### PR TITLE
memory improvements in dpkg scanner

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/scanner.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/scanner.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io"
 	"net/textproto"
-	"strings"
 )
 
 type dpkgScanner struct {
@@ -42,7 +41,7 @@ func emptyLineSplit(data []byte, atEOF bool) (advance int, token []byte, err err
 		return 0, nil, nil
 	}
 
-	if i := strings.Index(string(data), "\n\n"); i >= 0 {
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
 		// We have a full empty line terminated block.
 		return i + 2, data[0:i], nil
 	}

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -129,3 +129,9 @@ func RequiredFile(fileNames ...string) WalkDirRequiredFunc {
 		return slices.Contains(fileNames, filepath.Base(filePath))
 	}
 }
+
+func RequiredAll() WalkDirRequiredFunc {
+	return func(_ string, _ fs.DirEntry) bool {
+		return true
+	}
+}


### PR DESCRIPTION
## Description

This PR includes 2 big memory improvements:
- it makes `emptyLineSplit` alloc free, by skipping the bytes to string conversion
- it refactor and simplifies the scanning of files when parsing status and info files to not walk over a lot of unused files, and to parse status file only if it can be a status file

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
