### PR TITLE
Re-use existing `ErrorCallback` WalkOption in post-analysis fs walks

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -144,8 +144,9 @@ type PostAnalysisInput struct {
 }
 
 type AnalysisOptions struct {
-	Offline      bool
-	FileChecksum bool
+	Offline         bool
+	FileChecksum    bool
+	WalkErrCallback func(path string, err error) error
 }
 
 type AnalysisResult struct {

--- a/pkg/fanal/analyzer/language/dart/pub/pubspec.go
+++ b/pkg/fanal/analyzer/language/dart/pub/pubspec.go
@@ -110,7 +110,7 @@ func findDependsOn() (map[string][]string, error) {
 	}
 
 	deps := make(map[string][]string)
-	if err := fsutils.WalkDir(os.DirFS(dir), ".", required, nil, func(path string, d fs.DirEntry, r io.Reader) error {
+	if err := fsutils.WalkDir(os.DirFS(dir), ".", required, fsutils.DefaultWalkErrorCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		id, dependsOn, err := parsePubSpecYaml(r)
 		if err != nil {
 			log.Logger.Debugf("Unable to parse %q: %s", path, err)

--- a/pkg/fanal/analyzer/language/dart/pub/pubspec.go
+++ b/pkg/fanal/analyzer/language/dart/pub/pubspec.go
@@ -58,7 +58,7 @@ func (a pubSpecLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostA
 		return filepath.Base(path) == types.PubSpecLock
 	}
 
-	err = fsutils.WalkDir(input.FS, ".", required, func(path string, _ fs.DirEntry, r io.Reader) error {
+	err = fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, _ fs.DirEntry, r io.Reader) error {
 		app, err := language.Parse(types.Pub, path, r, a.parser)
 		if err != nil {
 			return xerrors.Errorf("unable to parse %q: %w", path, err)
@@ -110,7 +110,7 @@ func findDependsOn() (map[string][]string, error) {
 	}
 
 	deps := make(map[string][]string)
-	if err := fsutils.WalkDir(os.DirFS(dir), ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
+	if err := fsutils.WalkDir(os.DirFS(dir), ".", required, nil, func(path string, d fs.DirEntry, r io.Reader) error {
 		id, dependsOn, err := parsePubSpecYaml(r)
 		if err != nil {
 			log.Logger.Debugf("Unable to parse %q: %s", path, err)

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
@@ -57,7 +57,7 @@ func (a *nugetLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.Pos
 		return true
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		// Set the default parser
 		parser := a.lockParser
 

--- a/pkg/fanal/analyzer/language/golang/mod/mod.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod.go
@@ -70,7 +70,7 @@ func (a *gomodAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalys
 		return filepath.Base(path) == types.GoMod
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, _ io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, d fs.DirEntry, _ io.Reader) error {
 		// Parse go.mod
 		gomod, err := parse(input.FS, path, a.modParser)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/java/gradle/lockfile.go
+++ b/pkg/fanal/analyzer/language/java/gradle/lockfile.go
@@ -52,7 +52,7 @@ func (a gradleLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 	}
 
 	var apps []types.Application
-	err = fsutils.WalkDir(input.FS, ".", required, func(filePath string, _ fs.DirEntry, r io.Reader) error {
+	err = fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(filePath string, _ fs.DirEntry, r io.Reader) error {
 		var app *types.Application
 		app, err = language.Parse(types.Gradle, filePath, r, a.parser)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/java/gradle/pom.go
+++ b/pkg/fanal/analyzer/language/java/gradle/pom.go
@@ -77,7 +77,7 @@ func parsePoms() (map[string]pomXML, error) {
 	}
 
 	var poms = make(map[string]pomXML)
-	err := fsutils.WalkDir(os.DirFS(cacheDir), ".", required, func(path string, _ fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(os.DirFS(cacheDir), ".", required, nil, func(path string, _ fs.DirEntry, r io.Reader) error {
 		pom, err := parsePom(r, path)
 		if err != nil {
 			log.Logger.Debugf("Unable to parse %q: %s", path, err)

--- a/pkg/fanal/analyzer/language/java/gradle/pom.go
+++ b/pkg/fanal/analyzer/language/java/gradle/pom.go
@@ -77,7 +77,7 @@ func parsePoms() (map[string]pomXML, error) {
 	}
 
 	var poms = make(map[string]pomXML)
-	err := fsutils.WalkDir(os.DirFS(cacheDir), ".", required, nil, func(path string, _ fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(os.DirFS(cacheDir), ".", required, fsutils.DefaultWalkErrorCallback, func(path string, _ fs.DirEntry, r io.Reader) error {
 		pom, err := parsePom(r, path)
 		if err != nil {
 			log.Logger.Debugf("Unable to parse %q: %s", path, err)

--- a/pkg/fanal/analyzer/language/nodejs/license/license.go
+++ b/pkg/fanal/analyzer/language/nodejs/license/license.go
@@ -55,7 +55,7 @@ func (l *License) Traverse(fsys fs.FS, root string) (map[string][]string, error)
 		}
 		return nil
 	}
-	if err := fsutils.WalkDir(fsys, root, fsutils.RequiredFile(types.NpmPkg), walkDirFunc); err != nil {
+	if err := fsutils.WalkDir(fsys, root, fsutils.RequiredFile(types.NpmPkg), nil, walkDirFunc); err != nil {
 		return nil, xerrors.Errorf("walk error: %w", err)
 	}
 

--- a/pkg/fanal/analyzer/language/nodejs/license/license.go
+++ b/pkg/fanal/analyzer/language/nodejs/license/license.go
@@ -55,7 +55,7 @@ func (l *License) Traverse(fsys fs.FS, root string) (map[string][]string, error)
 		}
 		return nil
 	}
-	if err := fsutils.WalkDir(fsys, root, fsutils.RequiredFile(types.NpmPkg), nil, walkDirFunc); err != nil {
+	if err := fsutils.WalkDir(fsys, root, fsutils.RequiredFile(types.NpmPkg), fsutils.DefaultWalkErrorCallback, walkDirFunc); err != nil {
 		return nil, xerrors.Errorf("walk error: %w", err)
 	}
 

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -50,7 +50,7 @@ func (a npmLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 	}
 
 	var apps []types.Application
-	err := fsutils.WalkDir(input.FS, ".", required, func(filePath string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		// Find all licenses from package.json files under node_modules dirs
 		licenses, err := a.findLicenses(input.FS, filePath)
 		if err != nil {
@@ -140,7 +140,7 @@ func (a npmLibraryAnalyzer) findLicenses(fsys fs.FS, lockPath string) (map[strin
 	// Note that fs.FS is always slashed regardless of the platform,
 	// and path.Join should be used rather than filepath.Join.
 	licenses := make(map[string]string)
-	err := fsutils.WalkDir(fsys, root, required, func(filePath string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(fsys, root, required, nil, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		pkg, err := a.packageParser.Parse(r)
 		if err != nil {
 			return xerrors.Errorf("unable to parse %q: %w", filePath, err)

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -140,7 +140,7 @@ func (a npmLibraryAnalyzer) findLicenses(fsys fs.FS, lockPath string) (map[strin
 	// Note that fs.FS is always slashed regardless of the platform,
 	// and path.Join should be used rather than filepath.Join.
 	licenses := make(map[string]string)
-	err := fsutils.WalkDir(fsys, root, required, nil, func(filePath string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(fsys, root, required, fsutils.DefaultWalkErrorCallback, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		pkg, err := a.packageParser.Parse(r)
 		if err != nil {
 			return xerrors.Errorf("unable to parse %q: %w", filePath, err)

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
@@ -306,7 +306,7 @@ func (a yarnAnalyzer) traverseWorkspaces(fsys fs.FS, dir string, workspaces []st
 			return nil, err
 		}
 		for _, match := range matches {
-			if err := fsutils.WalkDir(fsys, match, required, nil, walkDirFunc); err != nil {
+			if err := fsutils.WalkDir(fsys, match, required, fsutils.DefaultWalkErrorCallback, walkDirFunc); err != nil {
 				return nil, xerrors.Errorf("walk error: %w", err)
 			}
 		}
@@ -380,7 +380,7 @@ func (a yarnAnalyzer) traverseUnpluggedDir(fsys fs.FS) (map[string][]string, err
 func (a yarnAnalyzer) traverseCacheDir(fsys fs.FS) (map[string][]string, error) {
 	// Traverse .yarn/cache dir
 	licenses := make(map[string][]string)
-	err := fsutils.WalkDir(fsys, "cache", fsutils.RequiredExt(".zip"), nil,
+	err := fsutils.WalkDir(fsys, "cache", fsutils.RequiredExt(".zip"), fsutils.DefaultWalkErrorCallback,
 		func(filePath string, d fs.DirEntry, r io.Reader) error {
 			fi, err := d.Info()
 			if err != nil {

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
@@ -64,7 +64,7 @@ func (a yarnAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		return filepath.Base(path) == types.YarnLock
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(filePath string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		// Parse yarn.lock
 		app, err := a.parseYarnLock(filePath, r)
 		if err != nil {
@@ -306,7 +306,7 @@ func (a yarnAnalyzer) traverseWorkspaces(fsys fs.FS, dir string, workspaces []st
 			return nil, err
 		}
 		for _, match := range matches {
-			if err := fsutils.WalkDir(fsys, match, required, walkDirFunc); err != nil {
+			if err := fsutils.WalkDir(fsys, match, required, nil, walkDirFunc); err != nil {
 				return nil, xerrors.Errorf("walk error: %w", err)
 			}
 		}
@@ -380,7 +380,7 @@ func (a yarnAnalyzer) traverseUnpluggedDir(fsys fs.FS) (map[string][]string, err
 func (a yarnAnalyzer) traverseCacheDir(fsys fs.FS) (map[string][]string, error) {
 	// Traverse .yarn/cache dir
 	licenses := make(map[string][]string)
-	err := fsutils.WalkDir(fsys, "cache", fsutils.RequiredExt(".zip"),
+	err := fsutils.WalkDir(fsys, "cache", fsutils.RequiredExt(".zip"), nil,
 		func(filePath string, d fs.DirEntry, r io.Reader) error {
 			fi, err := d.Info()
 			if err != nil {

--- a/pkg/fanal/analyzer/language/php/composer/composer.go
+++ b/pkg/fanal/analyzer/language/php/composer/composer.go
@@ -51,7 +51,7 @@ func (a composerAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnal
 		return filepath.Base(path) == types.ComposerLock
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		// Parse composer.lock
 		app, err := a.parseComposerLock(path, r)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/python/packaging/packaging.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging.go
@@ -67,7 +67,7 @@ func (a packagingAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 		return filepath.Base(path) == "METADATA" || isEggFile(path)
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		rsa, ok := r.(xio.ReadSeekerAt)
 		if !ok {
 			return xerrors.New("invalid reader")

--- a/pkg/fanal/analyzer/language/python/poetry/poetry.go
+++ b/pkg/fanal/analyzer/language/python/poetry/poetry.go
@@ -45,7 +45,7 @@ func (a poetryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalys
 		return filepath.Base(path) == types.PoetryLock
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		// Parse poetry.lock
 		app, err := a.parsePoetryLock(path, r)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo.go
@@ -59,7 +59,7 @@ func (a cargoAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysi
 		return filepath.Base(path) == types.CargoLock
 	}
 
-	err := fsutils.WalkDir(input.FS, ".", required, func(filePath string, d fs.DirEntry, r io.Reader) error {
+	err := fsutils.WalkDir(input.FS, ".", required, input.Options.WalkErrCallback, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		// Parse Cargo.lock
 		app, err := a.parseCargoLock(filePath, r)
 		if err != nil {

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -65,9 +65,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 
 	errCallback := input.Options.WalkErrCallback
 	if errCallback == nil {
-		errCallback = func(_ string, err error) error {
-			return err
-		}
+		errCallback = fsutils.DefaultWalkErrorCallback
 	}
 
 	// parse list files

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -74,7 +74,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		systemInstalledFiles = append(systemInstalledFiles, systemFiles...)
 		return nil
 	})
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, xerrors.Errorf("dpkg walk error: %w", err)
 	}
 
@@ -110,7 +110,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		packageInfos = append(packageInfos, infos...)
 		return nil
 	})
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, xerrors.Errorf("dpkg walk error: %w", err)
 	}
 

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -63,8 +63,15 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 
 	packageFiles := make(map[string][]string)
 
+	errCallback := input.Options.WalkErrCallback
+	if errCallback == nil {
+		errCallback = func(_ string, err error) error {
+			return err
+		}
+	}
+
 	// parse list files
-	err = fsutils.WalkDir(input.FS, infoDir, fsutils.RequiredExt(".list"), func(path string, d fs.DirEntry, r io.Reader) error {
+	err = fsutils.WalkDir(input.FS, infoDir, fsutils.RequiredExt(".list"), errCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		scanner := bufio.NewScanner(r)
 		systemFiles, err := a.parseDpkgInfoList(scanner)
 		if err != nil {
@@ -74,7 +81,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		systemInstalledFiles = append(systemInstalledFiles, systemFiles...)
 		return nil
 	})
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err != nil {
 		return nil, xerrors.Errorf("dpkg walk error: %w", err)
 	}
 
@@ -82,10 +89,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 	parseRootStatusFile := func() ([]types.PackageInfo, error) {
 		f, err := input.FS.Open(statusFile)
 		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				return nil, nil
-			}
-			return nil, xerrors.Errorf("failed to open %s: %w", statusFile, err)
+			return nil, errCallback(statusFile, fmt.Errorf("failed to open %s: %w", statusFile, err))
 		}
 		defer f.Close()
 
@@ -102,7 +106,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 	packageInfos = append(packageInfos, rootStatusInfos...)
 
 	// parse status files
-	err = fsutils.WalkDir(input.FS, statusDir, fsutils.RequiredAll(), func(path string, d fs.DirEntry, r io.Reader) error {
+	err = fsutils.WalkDir(input.FS, statusDir, fsutils.RequiredAll(), errCallback, func(path string, d fs.DirEntry, r io.Reader) error {
 		infos, err := a.parseDpkgStatus(path, r, digests)
 		if err != nil {
 			return err
@@ -110,7 +114,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		packageInfos = append(packageInfos, infos...)
 		return nil
 	})
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err != nil {
 		return nil, xerrors.Errorf("dpkg walk error: %w", err)
 	}
 

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"github.com/aquasecurity/trivy/pkg/misconf"
+	"github.com/aquasecurity/trivy/pkg/utils/fsutils"
 )
 
 type Option struct {
@@ -49,6 +50,13 @@ type Option struct {
 // This option is only available when using Trivy as an imported library and not through CLI flags.
 type WalkOption struct {
 	ErrorCallback walker.ErrorCallback
+}
+
+func (wo *WalkOption) GetErrorCallback() walker.ErrorCallback {
+	if wo == nil || wo.ErrorCallback == nil {
+		return fsutils.DefaultWalkErrorCallback
+	}
+	return wo.ErrorCallback
 }
 
 func (o *Option) AnalyzerOptions() analyzer.AnalyzerOptions {

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -250,8 +250,9 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 	// Prepare variables
 	var wg sync.WaitGroup
 	opts := analyzer.AnalysisOptions{
-		Offline:      a.artifactOption.Offline,
-		FileChecksum: a.artifactOption.FileChecksum,
+		Offline:         a.artifactOption.Offline,
+		FileChecksum:    a.artifactOption.FileChecksum,
+		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
 	}
 	result := analyzer.NewAnalysisResult()
 	limit := semaphore.New(a.artifactOption.Parallel)

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -252,7 +252,7 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 	opts := analyzer.AnalysisOptions{
 		Offline:         a.artifactOption.Offline,
 		FileChecksum:    a.artifactOption.FileChecksum,
-		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
+		WalkErrCallback: a.artifactOption.WalkOption.GetErrorCallback(),
 	}
 	result := analyzer.NewAnalysisResult()
 	limit := semaphore.New(a.artifactOption.Parallel)

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -123,8 +123,9 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 	result := analyzer.NewAnalysisResult()
 	limit := semaphore.New(a.artifactOption.Parallel)
 	opts := analyzer.AnalysisOptions{
-		Offline:      a.artifactOption.Offline,
-		FileChecksum: a.artifactOption.FileChecksum,
+		Offline:         a.artifactOption.Offline,
+		FileChecksum:    a.artifactOption.FileChecksum,
+		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
 	}
 
 	// Prepare filesystem for post analysis

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -125,7 +125,7 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 	opts := analyzer.AnalysisOptions{
 		Offline:         a.artifactOption.Offline,
 		FileChecksum:    a.artifactOption.FileChecksum,
-		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
+		WalkErrCallback: a.artifactOption.WalkOption.GetErrorCallback(),
 	}
 
 	// Prepare filesystem for post analysis

--- a/pkg/fanal/artifact/vm/vm.go
+++ b/pkg/fanal/artifact/vm/vm.go
@@ -86,8 +86,9 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 	result := analyzer.NewAnalysisResult()
 
 	opts := analyzer.AnalysisOptions{
-		Offline:      a.artifactOption.Offline,
-		FileChecksum: a.artifactOption.FileChecksum,
+		Offline:         a.artifactOption.Offline,
+		FileChecksum:    a.artifactOption.FileChecksum,
+		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
 	}
 
 	// Prepare filesystem for post analysis

--- a/pkg/fanal/artifact/vm/vm.go
+++ b/pkg/fanal/artifact/vm/vm.go
@@ -88,7 +88,7 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 	opts := analyzer.AnalysisOptions{
 		Offline:         a.artifactOption.Offline,
 		FileChecksum:    a.artifactOption.FileChecksum,
-		WalkErrCallback: a.artifactOption.WalkOption.ErrorCallback,
+		WalkErrCallback: a.artifactOption.WalkOption.GetErrorCallback(),
 	}
 
 	// Prepare filesystem for post analysis

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -110,11 +110,11 @@ func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, errCallback 
 
 		f, err := fsys.Open(path)
 		if err != nil {
-			oErr := fmt.Errorf("file open error: %w", err)
+			errOpen := fmt.Errorf("file open error: %w", err)
 			if errCallback != nil {
-				return errCallback(path, oErr)
+				return errCallback(path, errOpen)
 			}
-			return oErr
+			return errOpen
 		}
 		defer f.Close()
 

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -1,6 +1,7 @@
 package fsutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -83,6 +84,13 @@ func DirExists(path string) bool {
 		return false
 	}
 	return true
+}
+
+func DefaultWalkErrorCallback(_ string, err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return nil
+	}
+	return err
 }
 
 type WalkDirRequiredFunc func(path string, d fs.DirEntry) bool


### PR DESCRIPTION
## Description

This PR propagates the `ErrorCallback` WalkOption used by Artifacts to Post-analyzers so that this option can also be applied in post-analysis fs walks.

The motivation behind this change is to be able to ignore the same type of errors when walking the filesystem (`fs.ErrPermission` by default).

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
