### PR TITLE
remove `fmt.Println` call in `isDetectableJavaExecutable`

### DIFF
--- a/pkg/fanal/analyzer/executable/executable.go
+++ b/pkg/fanal/analyzer/executable/executable.go
@@ -2,7 +2,6 @@ package executable
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -78,7 +77,6 @@ func isDetectablePhpExecutable(fileInfo os.FileInfo) bool {
 }
 
 func isDetectableJavaExecutable(fileInfo os.FileInfo) bool {
-	fmt.Println(fileInfo.Name())
 	return filepath.Base(fileInfo.Name()) == "java"
 }
 


### PR DESCRIPTION
## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
