### PR TITLE
fix passing of `WalkErrCallback` for local container artifact

### DIFF
--- a/pkg/fanal/artifact/container/container.go
+++ b/pkg/fanal/artifact/container/container.go
@@ -257,8 +257,9 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 	// Prepare variables
 	var wg sync.WaitGroup
 	opts := analyzer.AnalysisOptions{
-		Offline:      a.artifactOption.Offline,
-		FileChecksum: a.artifactOption.FileChecksum,
+		Offline:         a.artifactOption.Offline,
+		FileChecksum:    a.artifactOption.FileChecksum,
+		WalkErrCallback: a.artifactOption.GetWalkerErrorCallback(),
 	}
 	result := analyzer.NewAnalysisResult()
 	limit := semaphore.New(a.artifactOption.Parallel)


### PR DESCRIPTION
## Description

This PR fixes the missing analysis option `WalkErrCallback` field when creating a container artifact.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
