### PR TITLE
re-introduce default dpkg analyzer error handling behavior

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -432,8 +432,7 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, wg *sync.WaitGroup, lim
 			break
 		} else if err != nil {
 			if opts.WalkErrCallback != nil {
-				err = opts.WalkErrCallback(filePath, err)
-				if err == nil {
+				if errCb := opts.WalkErrCallback(filePath, err); errCb == nil {
 					break
 				}
 			}

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -79,9 +79,14 @@ type WalkDirRequiredFunc func(path string, d fs.DirEntry) bool
 
 type WalkDirFunc func(path string, d fs.DirEntry, r io.Reader) error
 
-func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, errCallback func(_ string, _ error) error, fn WalkDirFunc) error {
+type WalkDirErrorCallback func(path string, err error) error
+
+func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, errCallback WalkDirErrorCallback, fn WalkDirFunc) error {
 	return fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				return nil
+			}
 			if errCallback != nil {
 				return errCallback(path, err)
 			}
@@ -92,6 +97,9 @@ func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, errCallback 
 
 		f, err := fsys.Open(path)
 		if err != nil {
+			if os.IsPermission(err) {
+				return nil
+			}
 			errOpen := fmt.Errorf("file open error: %w", err)
 			if errCallback != nil {
 				return errCallback(path, errOpen)


### PR DESCRIPTION
## Description

Re-introduce some of the default `dpkg` (and `fsutil.WalkDir`) error handling behavior that was altered by https://github.com/DataDog/trivy/pull/17.

Part of that work was already handled by 359ffe30c2c73877ba784797e699b55df6bde0e3

The goal is to make sure the default behavior is left untouched when no `ErrorCallback` walk option is passed down to the dpkg analyzer.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
