### PR TITLE
do not crash when no partial result on deadline expired error

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -526,7 +526,11 @@ func (ag AnalyzerGroup) PostAnalyze(ctx context.Context, compositeFS *CompositeF
 		}, opts.PostAnalyzerTimeout)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				err = xerrors.Errorf("%s post analysis timeout after %d results: %w", a.Type(), len(res.Applications), err)
+				appCount := 0
+				if res != nil {
+					appCount = len(res.Applications)
+				}
+				err = xerrors.Errorf("%s post analysis timeout after %d results: %w", a.Type(), appCount, err)
 				errs = errors.Join(errs, err)
 			} else {
 				return xerrors.Errorf("post analysis error: %w", err)


### PR DESCRIPTION
## Description

When we hit a deadline expired error, we might have a `nil` result and we currently don't handle this case correctly. This PR fixes this by default the app count to 0 when res is nil.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
