### PR TITLE
fix(image): don't reject remote images whose ArtifactType is just a config media type

### DIFF
--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -21,9 +22,11 @@ func tryRemote(ctx context.Context, imageName string, ref name.Reference, option
 	if err != nil {
 		return nil, cleanup, err
 	}
-	// ArtifactType being non-empty indicates this is not a regular container image
-	// (e.g., Helm charts, WASM modules, or other OCI artifacts)
-	if desc.ArtifactType != "" {
+
+	// An empty ArtifactType or an ArtifactType with a config media type indicates a
+	// regular container image. Any other ArtifactType is treated as a non-image
+	// artifact (e.g., Helm charts, WASM modules, or other OCI artifacts).
+	if desc.ArtifactType != "" && !v1types.MediaType(desc.ArtifactType).IsConfig() {
 		return nil, cleanup, xerrors.Errorf("unsupported artifact type %q for image %q", desc.ArtifactType, imageName)
 	}
 	img, err := desc.Image()

--- a/pkg/fanal/image/remote_test.go
+++ b/pkg/fanal/image/remote_test.go
@@ -145,6 +145,29 @@ func Test_tryRemote(t *testing.T) {
 			wantErr: "unsupported artifact type",
 		},
 		{
+			// Regression test: a single-arch image manifest (as opposed to a
+			// multi-arch manifest list/index) has a Config field, and when the
+			// manifest itself doesn't set an explicit `artifactType`,
+			// go-containerregistry falls back to using the config's media type
+			// as the descriptor's ArtifactType. A regular container image config
+			// media type must NOT be treated as an unsupported artifact type.
+			name:      "regular image with explicit docker config media type",
+			imageName: "test/dockerconfig:latest",
+			setupImage: func(t *testing.T, ref name.Reference) {
+				configFile, err := img.ConfigFile()
+				require.NoError(t, err)
+
+				imageToWrite, err := mutate.Config(img, configFile.Config)
+				require.NoError(t, err)
+
+				imageToWrite = mutate.ConfigMediaType(imageToWrite, "application/vnd.docker.container.image.v1+json")
+
+				err = remote.Write(ref, imageToWrite)
+				require.NoError(t, err)
+			},
+			wantName: "/test/dockerconfig:latest",
+		},
+		{
 			name:       "image not found",
 			imageName:  "test/notfound:latest",
 			wantErr:    "NAME_UNKNOWN",


### PR DESCRIPTION
## Summary
- Backports the fix from upstream aquasecurity/trivy (present as of v0.72.0, commit 3ea80c097d) using the `IsConfig()` helper already available in this fork's go-containerregistry version -- no dependency bump required.
- Single-architecture image manifests (i.e. a tag resolving directly to an image manifest rather than a multi-arch manifest list/index) have a `Config` field. When the manifest has no explicit `artifactType`, go-containerregistry falls back to setting `Descriptor.ArtifactType` to the config's media type (e.g. `application/vnd.docker.container.image.v1+json`).
- `tryRemote`'s check for non-image OCI artifacts (Helm charts, WASM modules, etc.) didn't account for this, so plain single-arch images pulled via the `remote` image source fallback were incorrectly rejected with:

  ```
  remote error: unsupported artifact type "application/vnd.docker.container.image.v1+json" for image "..."
  ```

  This was hit by a datadog-security-cli customer scanning an ECR image directly (no local Docker/containerd/podman available), and reproduces for any single-arch image pulled via the remote fallback.


## Test plan
- [x] Added a regression test case (`regular image with explicit docker config media type`) to `Test_tryRemote`
- [x] Verified against go-containerregistry v0.21.7 (the version datadog-security-cli actually resolves via MVS, since it requires it directly) that the bug reproduces without the fix and is resolved with it
- [x] Confirmed the existing `helm chart config media type` rejection test still passes (no regression on the original intent of the check)

## Links
- Upstream fix: https://github.com/aquasecurity/trivy/commit/3ea80c097d3f777c9c8f2335508309c38e741172
- Bug introduced by: https://github.com/aquasecurity/trivy/issues/9052

Made with [Cursor](https://cursor.com)