### PR TITLE
feat(ubuntu): match FIPS packages against the dedicated FIPS bucket

### DIFF
--- a/pkg/detector/ospkg/ubuntu/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/ubuntu/testdata/fixtures/data-source.yaml
@@ -10,3 +10,8 @@
         ID: "ubuntu"
         Name: "Ubuntu CVE Tracker"
         URL: "https://git.launchpad.net/ubuntu-cve-tracker"
+    - key: ubuntu 20.04-FIPS
+      value:
+        ID: "ubuntu"
+        Name: "Ubuntu CVE Tracker"
+        URL: "https://git.launchpad.net/ubuntu-cve-tracker"

--- a/pkg/detector/ospkg/ubuntu/testdata/fixtures/ubuntu.yaml
+++ b/pkg/detector/ospkg/ubuntu/testdata/fixtures/ubuntu.yaml
@@ -18,3 +18,10 @@
         - key: CVE-2016-4476
           value:
             FixedVersion: "2.4-0ubuntu10"
+- bucket: ubuntu 20.04-FIPS
+  pairs:
+    - bucket: openssl
+      pairs:
+        - key: CVE-2099-FIPS
+          value:
+            FixedVersion: "3.0.2-0ubuntu1.17+Fips2"

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -103,6 +103,8 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
 		log.Int("pkg_num", len(pkgs)))
 
+	release := s.versionFromEolDates(ctx, osVer)
+
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
 		// Skip third-party packages as they are not covered by Ubuntu security advisories
@@ -110,9 +112,16 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 			continue
 		}
 
-		osVer = s.versionFromEolDates(ctx, osVer)
+		// FIPS-validated packages are fixed on Ubuntu's FIPS streams, which
+		// trivy-db stores in a dedicated "<version>-FIPS" bucket. Querying that
+		// bucket (instead of the regular release bucket) ensures FIPS users get
+		// the FIPS-validated fixed version, and non-FIPS users are unaffected.
+		pkgRelease := release
+		if isFIPSPackage(pkg) {
+			pkgRelease += "-FIPS"
+		}
 		advisories, err := s.vs.Get(db.GetParams{
-			Release: osVer,
+			Release: pkgRelease,
 			PkgName: pkg.SrcName,
 		})
 		if err != nil {
@@ -162,6 +171,20 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
 	osVer = s.versionFromEolDates(ctx, osVer)
 	return osver.Supported(ctx, s.eolDates, osFamily, osVer)
+}
+
+// isFIPSPackage reports whether a package is a FIPS-validated build, based on
+// the FIPS marker Ubuntu adds to the package version (e.g. "3.0.2-0ubuntu1.17+Fips1").
+// Such packages are fixed on Ubuntu's FIPS streams and must be matched against
+// the dedicated "<version>-FIPS" bucket rather than the regular release bucket.
+func isFIPSPackage(pkg ftypes.Package) bool {
+	for _, v := range []string{utils.FormatVersion(pkg), utils.FormatSrcVersion(pkg)} {
+		v = strings.ToLower(v)
+		if strings.Contains(v, "+fips") || strings.Contains(v, ".fips.") {
+			return true
+		}
+	}
+	return false
 }
 
 // versionFromEolDates checks if actual (not ESM) version is not outdated

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -166,6 +166,65 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name: "FIPS package is matched against the FIPS bucket",
+			fixtures: []string{
+				"testdata/fixtures/ubuntu.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "20.04",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "openssl",
+						Version:    "3.0.2-0ubuntu1.17+Fips1",
+						SrcName:    "openssl",
+						SrcVersion: "3.0.2-0ubuntu1.17+Fips1",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "openssl",
+					VulnerabilityID:  "CVE-2099-FIPS",
+					InstalledVersion: "3.0.2-0ubuntu1.17+Fips1",
+					FixedVersion:     "3.0.2-0ubuntu1.17+Fips2",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Ubuntu,
+						Name: "Ubuntu CVE Tracker",
+						URL:  "https://git.launchpad.net/ubuntu-cve-tracker",
+					},
+				},
+			},
+		},
+		{
+			name: "non-FIPS package does not match the FIPS bucket",
+			fixtures: []string{
+				"testdata/fixtures/ubuntu.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "20.04",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "openssl",
+						Version:    "3.0.2-0ubuntu1.17",
+						SrcName:    "openssl",
+						SrcVersion: "3.0.2-0ubuntu1.17",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
 			name: "broken bucket",
 			fixtures: []string{
 				"testdata/fixtures/invalid.yaml",


### PR DESCRIPTION
## Summary

Make the Ubuntu detector query a dedicated FIPS advisory bucket for FIPS-validated packages.

Ubuntu ships FIPS-validated packages (e.g. `openssl`) that are fixed on its FIPS streams (`fips/`, `fips-updates/`, `fips-preview/`). The companion trivy-db change stores those advisories in a dedicated `ubuntu <version>-FIPS` bucket instead of the regular release bucket, so FIPS and non-FIPS fixed versions no longer collide.

This PR teaches the scanner to:
- detect a FIPS package by the FIPS version marker Ubuntu adds (`+Fips`/`+fips`, or `.fips.`), and
- for those packages, query the `<version>-FIPS` bucket; non-FIPS packages keep querying the regular release bucket.

As a result FIPS-validated fixes are shown only to FIPS users, and non-FIPS users are unaffected.

## Changes

- `pkg/detector/ospkg/ubuntu/ubuntu.go`
  - Resolve the base release once, then per package append `-FIPS` when `isFIPSPackage(pkg)` before calling `VulnSrc.Get`.
  - Add the `isFIPSPackage` helper (checks binary and source version strings, case-insensitive).
- `pkg/detector/ospkg/ubuntu/ubuntu_test.go`: add a FIPS-package case (matched in `ubuntu 20.04-FIPS`) and a non-FIPS case (must not match the FIPS bucket).
- `testdata/fixtures/{ubuntu,data-source}.yaml`: add an `ubuntu 20.04-FIPS` bucket + data source.

No `go.mod` bump is required: the scanner only changes the bucket-name string passed to `Get`. The real `-FIPS` buckets are produced by the companion trivy-db PR once the DB is rebuilt.

## Companion PR

- trivy-db: https://github.com/DataDog/trivy-db/pull/60

## References

- Upstream discussion: https://github.com/aquasecurity/trivy-db/pull/664

## Testing

`go test ./pkg/detector/ospkg/ubuntu/...` passes.

Made with [Cursor](https://cursor.com)